### PR TITLE
Acknowledge weighted games

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -188,8 +188,15 @@ pub fn add_yaml_to_room(
     let game_name = match &parsed.game {
         YamlGame::Name(name) => name.clone(),
         YamlGame::Map(map) => {
-            if map.len() == 1 {
-                map.keys().next().unwrap().clone()
+            let weighted_map: HashMap<&String, &f64> = map
+                .iter()
+                .filter(|(_, &weight)| weight >= 1.0)
+                .collect();
+
+            if weighted_map.len() == 1 {
+                weighted_map.keys().next().unwrap().to_string()
+            } else if weighted_map.len() > 1 {
+                format!("Random ({})", weighted_map.len())
             } else {
                 "Unknown".to_string()
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -188,10 +188,8 @@ pub fn add_yaml_to_room(
     let game_name = match &parsed.game {
         YamlGame::Name(name) => name.clone(),
         YamlGame::Map(map) => {
-            let weighted_map: HashMap<&String, &f64> = map
-                .iter()
-                .filter(|(_, &weight)| weight >= 1.0)
-                .collect();
+            let weighted_map: HashMap<&String, &f64> =
+                map.iter().filter(|(_, &weight)| weight >= 1.0).collect();
 
             if weighted_map.len() == 1 {
                 weighted_map.keys().next().unwrap().to_string()

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -91,7 +91,7 @@ fn room<'a>(
     let unique_player_count = yamls.iter().unique_by(|yaml| yaml.0.owner_id).count();
     let unique_game_count = yamls
         .iter()
-        .filter(|yaml| !&yaml.0.game.starts_with("Random"))
+        .filter(|yaml| !&yaml.0.game.starts_with("Random ("))
         .unique_by(|yaml| &yaml.0.game)
         .count();
 

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -89,7 +89,10 @@ fn room<'a>(
     let mut yamls = db::get_yamls_for_room_with_author_names(uuid, ctx)?;
     yamls.sort_by(|a, b| a.0.game.cmp(&b.0.game));
     let unique_player_count = yamls.iter().unique_by(|yaml| yaml.0.owner_id).count();
-    let unique_game_count = yamls.iter().unique_by(|yaml| &yaml.0.game).count();
+    let unique_game_count = yamls
+        .iter()
+        .filter(|yaml| !&yaml.0.game.starts_with("Random"))
+        .unique_by(|yaml| &yaml.0.game).count();
 
     let is_my_room = session.is_admin || session.user_id == Some(room.author_id);
     let current_user_has_yaml_in_room = yamls

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -92,7 +92,8 @@ fn room<'a>(
     let unique_game_count = yamls
         .iter()
         .filter(|yaml| !&yaml.0.game.starts_with("Random"))
-        .unique_by(|yaml| &yaml.0.game).count();
+        .unique_by(|yaml| &yaml.0.game)
+        .count();
 
     let is_my_room = session.is_admin || session.user_id == Some(room.author_id);
     let current_user_has_yaml_in_room = yamls


### PR DESCRIPTION
```yaml
game: Game
---
game:
  Game: 1
  ...: 0
```
`Unknown` > `Game`

```yaml
game:
  Game: 1
  Game 2: 1
  Game HD: 1
  Son of Game: 0
```
`Unknown` > `Random (3)`, the number of non-zero weighted games

```yaml
game:
  Game: 0
  Game 2: 0
  Game HD: 0
```
`Unknown` The *validator* would catch this but the generator will still error

`Random` hints the worlds should be verified and `(#)` hints how volatile it is at a glance.    
`Random (#)` is removed from the unique game count while `Unknown` is still counted but less frequent.    
Maybe filter in `upload_yaml()`, error for 0, and pass the filtered list on?