### PR TITLE
Add Kingdom Hearts deathlink Extractor, fix Extractor probability calculation

### DIFF
--- a/src/extractor/kh.rs
+++ b/src/extractor/kh.rs
@@ -1,0 +1,16 @@
+use super::{Extractor, FeatureExtractor, YamlFeature};
+use crate::error::Result;
+
+pub struct KingdomHearts;
+
+impl FeatureExtractor for KingdomHearts {
+    fn game(&self) -> &'static str {
+        "Kingdom Hearts"
+    }
+
+    fn extract_features(&self, extractor: &mut Extractor) -> Result<()> {
+        extractor.register_feature(YamlFeature::DeathLink, "donald_death_link")?;
+        extractor.register_feature(YamlFeature::DeathLink, "goofy_death_link")?;
+        Ok(())
+    }
+}

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::collections::HashMap;
 
 use crate::error::Result;
@@ -134,12 +133,13 @@ impl<'a> Extractor<'a> {
     }
 
     pub fn with_weight(&mut self, weight: u32, inner: fn(&mut Self) -> Result<()>) -> Result<()> {
-        if weight > MAX_WEIGHT {
-            panic!(
-                "Maximum weight: {}, Supplied weight: {}",
-                MAX_WEIGHT, weight
-            )
-        }
+        assert!(
+            weight <= MAX_WEIGHT,
+            "Maximum weight: {}, supplied weight: {}",
+            MAX_WEIGHT,
+            weight
+        );
+
         self.current_weight = weight;
         inner(self)?;
         self.current_weight = MAX_WEIGHT;


### PR DESCRIPTION
There's two distinct ways that probability values need to be combined here:

- Matching features in the same game
- Matching features across different games

When combining features across games the probabilities can simply be added as they are already scaled for their respective games and are dependent.

When combining different YAML options into the same feature in the same game the probabilities are independent, so it's not correct to sum them. Instead you can take the probability of each individual option **not** happening, multiply them to get the chance of **both** options **not** happening and then inverse that, which is the probability of **either** option happening.

